### PR TITLE
Chore: use box for functon in favor of R namespaces

### DIFF
--- a/app/logic/Tplyr_helpers.R
+++ b/app/logic/Tplyr_helpers.R
@@ -1,5 +1,6 @@
 box::use(
   dplyr[across, starts_with, arrange, mutate, bind_rows, select, distinct, rename],
+  tidyr[replace_na],
 )
 
 #' Nest Row Labels in a Tplyr table
@@ -26,6 +27,6 @@ nest_rowlabels <- function(.dat) {
     bind_rows(stubs) |>
     arrange(ord_layer_index, ord_layer_1, ord_layer_2) |>
     mutate(
-      across(starts_with("var"), ~ tidyr::replace_na(., ""))
+      across(starts_with("var"), ~ replace_na(., ""))
     )
 }

--- a/app/logic/eff_models.R
+++ b/app/logic/eff_models.R
@@ -63,7 +63,7 @@ efficacy_models <- function(data, var = NULL, wk = NULL, show_pvalue = TRUE) {
   ancova <- drop1(model1, . ~ ., test = "F")
 
   # Pull it out into a table
-  sect1 <- tibble::tibble(
+  sect1 <- tibble(
     row_label = c("p-value(Dose Response) [1][2]"),
     `81` = ifelse(
       show_pvalue,
@@ -81,17 +81,17 @@ efficacy_models <- function(data, var = NULL, wk = NULL, show_pvalue = TRUE) {
 
   # Linear model but use treatment group as a factor now
   # LS Means and weight proportionately to match OM option on PROC GLM in SAS
-  lsm <- emmeans::lsmeans(model2, ~TRTPCD_F, weights = "proportional")
+  lsm <- lsmeans(model2, ~TRTPCD_F, weights = "proportional")
 
   # Here on out - it's all the same data manipulation
   # Get pairwise contrast and remove P-values adjustment for multiple groups
-  cntrst_p <- emmeans::contrast(lsm, method = "pairwise", adjust = NULL)
+  cntrst_p <- contrast(lsm, method = "pairwise", adjust = NULL)
   # 95% CI
   cntrst_ci <- confint(cntrst_p)
 
   # merge and convert into dataframe
-  pw_data <- tibble::as_tibble(summary(cntrst_p)) |>
-    merge(tibble::as_tibble(cntrst_ci)) |>
+  pw_data <- as_tibble(summary(cntrst_p)) |>
+    merge(as_tibble(cntrst_ci)) |>
     rowwise() |>
     # Create the display strings
     mutate(
@@ -116,7 +116,7 @@ efficacy_models <- function(data, var = NULL, wk = NULL, show_pvalue = TRUE) {
     # Clean out the numeric variables
     select(contrast, p, diff_se, ci) |>
     # Transpose
-    tidyr::pivot_longer(c("p", "diff_se", "ci"), names_to = "row_label")
+    pivot_longer(c("p", "diff_se", "ci"), names_to = "row_label")
 
   # Subset Xan_Lo - Pbo into table variables
   xan_lo <- pw_data |>

--- a/app/logic/helpers.R
+++ b/app/logic/helpers.R
@@ -66,7 +66,7 @@ num_fmt <- Vectorize(function(var, digits = 0, size = 10, int_len = 3) {
 #' @return HTML with font size applied
 #' @export
 tooltip_text <- function(text, font_size = 16) {
-  glue::glue("<span style='font-size:{font_size}px;'>{text}<span>")
+  glue("<span style='font-size:{font_size}px;'>{text}<span>")
 }
 
 #' check if a filter is active in a teal module
@@ -78,10 +78,10 @@ tooltip_text <- function(text, font_size = 16) {
 filter_active <- function(datasets) {
   result <- FALSE
   if (length(names(datasets$get_filter_state()) > 0)) {
-    filter_use <- purrr::map_lgl(names(datasets$get_filter_state()), ~ {
+    filter_use <- map_lgl(names(datasets$get_filter_state()), ~ {
       # grab call of filter code
       f_call <- datasets$get_call(.x)$filter
-      f_call != glue::glue("{.x}_FILTERED <- {.x}")
+      f_call != glue("{.x}_FILTERED <- {.x}")
     })
     result <- any(filter_use)
   }

--- a/app/logic/kmplot_helpers.R
+++ b/app/logic/kmplot_helpers.R
@@ -35,7 +35,7 @@ add_risktable2 <- function(gg,
   if (is.null(times)) times <- graphtimes
 
   final <-
-    visR:::get_risktable(estimate_object,
+    get_risktable(estimate_object,
       times = times,
       statlist = statlist,
       label = label,
@@ -51,13 +51,13 @@ add_risktable2 <- function(gg,
   attr(final, "statlist") <- NULL
   attr(final, "title") <- NULL
 
-  tbls <- base::Map(
+  tbls <- Map(
     function(statlist, title = NA) {
       ggrisk <- ggplot(
         final,
         aes(
           x = time,
-          y = stats::reorder(y_values, dplyr::desc(y_values)),
+          y = reorder(y_values, desc(y_values)),
           label = format(get(statlist), nsmall = 0)
         )
       ) +
@@ -100,12 +100,12 @@ add_risktable2 <- function(gg,
   )
 
   gglist <- list(gg) |>
-    base::append(tbls)
+    append(tbls)
 
   gg_a <- gglist |>
-    visR:::align_plots()
+    align_plots()
 
-  gg_b <- cowplot::plot_grid(
+  gg_b <- plot_grid(
     plotlist = gg_a,
     align = "none",
     nrow = length(gg_a),

--- a/app/view/completion_table.R
+++ b/app/view/completion_table.R
@@ -43,7 +43,7 @@ server <- function(input, output, session, datasets) {
       )
 
     # visit number and week lookup
-    v_week_df <- tibble::tibble(
+    v_week_df <- tibble(
       AVISITN = c(0, 2, 4, 6, 8, 12, 16, 20, 24, 26, 99),
       VISIT = c("Baseline ", paste("Week", c(2, 4, 6, 8, 12, 16, 20, 24, 26)), "End of Treatment")
     ) |>

--- a/app/view/efficacy_table.R
+++ b/app/view/efficacy_table.R
@@ -21,7 +21,7 @@ ui <- function(id, datasets) {
     tags$br(),
     tags$br(),
     fluidRow(
-      tippy::tippy(
+      tippy(
         h4("Primary Endpoint Analysis: Glucose (mmol/L) - Summary at Week 20 LOCF"),
         tooltip = tooltip_text(
           "Table is based on participants who have observable data at Baseline and Week 20",
@@ -32,14 +32,14 @@ ui <- function(id, datasets) {
       tags$br(), tags$br(),
       column(
         width = 10,
-        reactable::reactableOutput(ns("tbl_efficacy_1"))
+        reactableOutput(ns("tbl_efficacy_1"))
       )
     ),
     tags$br(),
     tags$br(),
     tags$hr(),
     fluidRow(
-      tippy::tippy(
+      tippy(
         h4("Pairwise Comparison"),
         tooltip = tooltip_text(
           "Inference in this table is based on a Analysis of Covariance (ANCOVA) model
@@ -52,7 +52,7 @@ ui <- function(id, datasets) {
       tags$br(),
       column(
         width = 10,
-        reactable::reactableOutput(ns("tbl_efficacy_2"))
+        reactableOutput(ns("tbl_efficacy_2"))
       )
     ),
     tags$br(),
@@ -90,7 +90,7 @@ server <- function(input, output, session, datasets) {
       filter(TRTPN %in% c(0, 81), PARAMCD == "GLUC", !is.na(AVISITN)) |>
       mutate(TRTPN = ifelse(TRTPN == 0, 99, TRTPN))
 
-    gluc_lmfit <- stats::lm(
+    gluc_lmfit <- lm(
       CHG ~ BASE + TRTPN,
       data = adlb1 |>
         filter(AVISITN == 20)
@@ -118,7 +118,7 @@ server <- function(input, output, session, datasets) {
       )
 
     ## Calculate LS mean
-    t12 <- emmeans::emmeans(gluc_lmfit, "TRTPN")
+    t12 <- emmeans(gluc_lmfit, "TRTPN")
 
     ## Merge and format data for reporting
     apr0ancova1 <- merge(t10, t11) |>
@@ -162,7 +162,7 @@ server <- function(input, output, session, datasets) {
       apr0ancova3 = apr0ancova3
     )
   })
-  output$tbl_efficacy_1 <- reactable::renderReactable({
+  output$tbl_efficacy_1 <- renderReactable({
     efficacy_results <- efficacy_results()
     apr0ancova1 <- efficacy_results$apr0ancova1
     coln <- c(
@@ -188,7 +188,7 @@ server <- function(input, output, session, datasets) {
       )
     )
   })
-  output$tbl_efficacy_2 <- reactable::renderReactable({
+  output$tbl_efficacy_2 <- renderReactable({
     efficacy_results <- efficacy_results()
     apr0ancova2 <- efficacy_results$apr0ancova2
     apr0ancova3 <- efficacy_results$apr0ancova3


### PR DESCRIPTION
## Changes description

* replace all mentions of `📦::` with equivalent `box::use`
* cannot do that for un-exported function being called in `kmplot_helpers.R`